### PR TITLE
Change photon and limelight to use Robot Shared DOES THIS WORK

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 - [ ] Import old code
 - [x] Grab the lamelight from last years robot
 - [x] Set up lamelight (Photon vision) ([see last year's repo](#last-years-repo))
+- [ ] Rename instances of vision with photonVision for clarity
 - [ ] Incorperate lamelight table with shuffleboard
 - [ ] Calibrate lamelight
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -54,7 +54,7 @@ public class RobotContainer {
     autoChooser = AutoBuilder.buildAutoChooser();
 
     //Must register commands used in PathPlanner autos
-    NamedCommands.registerCommand("AlignToTagPhotonVision", new AlignToTagPhotonVision(m_robotDrive, m_vision));
+    NamedCommands.registerCommand("AlignToTagPhotonVision", new AlignToTagPhotonVision());
 
     // Configure the button bindings
     configureButtonBindings();

--- a/src/main/java/frc/robot/RobotShared.java
+++ b/src/main/java/frc/robot/RobotShared.java
@@ -8,6 +8,8 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.constants.OIConstants;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.HornSubsystem;
+import frc.robot.subsystems.LimelightSubsystem;
+import frc.robot.subsystems.PhotonVision;
 
 public class RobotShared {
 
@@ -17,6 +19,9 @@ public class RobotShared {
   protected HornSubsystem m_horn = null;
 
   protected final CommandXboxController m_driverController = new CommandXboxController(OIConstants.kDriverControllerPort);
+
+  protected LimelightSubsystem m_limelight = null;
+  protected PhotonVision m_photonVision = null;
 
   private static RobotShared instance;
 
@@ -42,7 +47,18 @@ public class RobotShared {
   public CommandXboxController getDriverController() {
     return m_driverController;
   }
-
+  public LimelightSubsystem getLimelight() {
+    if(m_limelight == null) {
+        m_limelight = new LimelightSubsystem();
+    }
+    return m_limelight;
+  }
+  public PhotonVision getPhotonVision() {
+    if(m_photonVision == null) {
+        m_photonVision = new PhotonVision();
+    }
+    return m_photonVision;
+  }
   public Alliance GetAlliance(){
     if(m_alliance.isPresent()){
       if(m_alliance.get() == Alliance.Blue){

--- a/src/main/java/frc/robot/commands/AlignToTagLimelight.java
+++ b/src/main/java/frc/robot/commands/AlignToTagLimelight.java
@@ -8,11 +8,15 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.constants.DriveCommandConstants;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.LimelightSubsystem;
+import frc.robot.RobotShared;
 
 public class AlignToTagLimelight extends Command {
   /** Creates a new AlignToTagLimelight. */
-  DriveSubsystem m_drive;
-  LimelightSubsystem m_limelight;
+  private DriveSubsystem m_drive;
+  private LimelightSubsystem m_limelight;
+
+  private RobotShared m_robotShared;
+
   double x_error;
   double y_error;
   double theta_error;
@@ -22,10 +26,10 @@ public class AlignToTagLimelight extends Command {
   boolean YFinished;
   boolean ThetaFinished;
 
-  public AlignToTagLimelight(DriveSubsystem drive, LimelightSubsystem limelight) {
-    addRequirements(drive);
-    m_drive = drive;
-    m_limelight = limelight;
+  public AlignToTagLimelight() {
+    m_robotShared = RobotShared.getInstance();
+    m_drive = m_robotShared.getDriveSubsystem();
+    m_limelight = m_robotShared.getLimelight();
   }
 
   // Called when the command is initially scheduled.

--- a/src/main/java/frc/robot/commands/AlignToTagPhotonVision.java
+++ b/src/main/java/frc/robot/commands/AlignToTagPhotonVision.java
@@ -6,6 +6,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.RobotShared;
 import frc.robot.constants.DriveCommandConstants;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.PhotonVision;
@@ -15,6 +16,8 @@ public class AlignToTagPhotonVision extends Command {
   DriveSubsystem m_drive;
   PhotonVision m_vision;
   Transform3d camToTarget;
+  private RobotShared m_robotShared;
+
   double x_error;
   double y_error;
   double theta_error;
@@ -22,12 +25,10 @@ public class AlignToTagPhotonVision extends Command {
   boolean YFinished;
   boolean ThetaFinished;
 
-  public AlignToTagPhotonVision(DriveSubsystem drive, PhotonVision Vision) {
-    addRequirements(drive);
-    m_drive = drive;
-    m_vision = Vision;
-
-    // Use addRequirements() here to declare subsystem dependencies.
+  public AlignToTagPhotonVision() {
+    m_robotShared = RobotShared.getInstance();
+    m_drive = m_robotShared.getDriveSubsystem();
+    m_vision = m_robotShared.getPhotonVision();
   }
 
   // Called when the command is initially scheduled.

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -16,6 +16,7 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.util.WPIUtilJNI;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.SerialPort;
+import frc.robot.RobotShared;
 import frc.robot.constants.DriveConstants;
 import frc.utils.SwerveUtils;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -45,6 +46,7 @@ public class DriveSubsystem extends SubsystemBase {
       DriveConstants.kRearRightTurningCanId,
       DriveConstants.kBackRightChassisAngularOffset);
 
+  private RobotShared m_robotShared = RobotShared.getInstance();
   // The gyro sensor
   private AHRS m_gyro = new AHRS(SerialPort.Port.kMXP);
 
@@ -78,9 +80,8 @@ public class DriveSubsystem extends SubsystemBase {
         m_rearLeft.getPosition(),
         m_rearRight.getPosition()
       }, new Pose2d());
-  
   //Vision
-  PhotonVision m_vision = new PhotonVision();
+  PhotonVision m_vision = m_robotShared.getPhotonVision();
 
   /** Creates a new DriveSubsystem. */
   public DriveSubsystem() {


### PR DESCRIPTION
I changed the photon vision to use robot shared, will the path planner still work? hypothetically it should, but does pathplanner need to directly pass in subsystems or can it handle being abstracted through robotShared?